### PR TITLE
Adding missing dependency to pretty-bytes

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   },
   "dependencies": {
     "svgo": "~0.4.1",
-    "cheerio": "~0.13.1"
+    "cheerio": "~0.13.1",
+    "pretty-bytes":"~0.1.1"
   },
   "peerDependencies": {
     "grunt": "~0.4.4"


### PR DESCRIPTION
If this module is installed now, it doesn't work because of a missing dependency. This fixes this issue!
